### PR TITLE
fix: ensureNotAuthenticated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,12 +37,19 @@ class EdfContentScript extends ContentScript {
       return true
     }
     this.log('info', 'authenticated, triggering the deconnection')
-    window.deconnexion()
-    await this.waitForElementInWorker('#connexion')
+    await this.runInWorker('logout')
+    await this.waitForElementInWorker(`[data-label='Je me reconnecte']`)
     return true
   }
 
-  async ensureAuthenticated() {
+  async logout() {
+    window.deconnexion()
+  }
+
+  async ensureAuthenticated(account) {
+    if (!account) {
+      await this.ensureNotAuthenticated()
+    }
     await this.goToLoginForm()
     if (await this.runInWorker('checkAuthenticated')) {
       this.log('info', 'Authenticated')
@@ -675,7 +682,8 @@ connector
       'getHomeProfile',
       'getContractElec',
       'getConsumptions',
-      'waitForSessionStorage'
+      'waitForSessionStorage',
+      'logout'
     ]
   })
   .catch(err => {


### PR DESCRIPTION
- window.deconnexion was run in the pilot by mistake. The disconnection
worked but only for the next run

- the wait after deconnexion was wrong and resolved too soon

- now run ensureNotAuthenticated if we are in the first run
