### PR TITLE
feat: Edf konnector optimization base on context

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -8,7 +8,7 @@
   "slug": "edf",
   "source": "git@github.com:konnectors/edf.git",
   "editor": "Cozy",
-  "vendor_link": "https://particulier.edf.fr/fr/accueil/aide-contact/faq.html",
+  "vendor_link": "https://particulier.edf.fr/fr/accueil.html",
   "categories": [
     "energy"
   ],

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,7 @@ class EdfContentScript extends ContentScript {
     window.deconnexion()
   }
 
-  async ensureAuthenticated(account) {
+  async ensureAuthenticated({ account }) {
     if (!account) {
       await this.ensureNotAuthenticated()
     }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import Minilog from '@cozy/minilog'
 import { format } from 'date-fns'
 import waitFor from 'p-wait-for'
 import { formatHousing } from './utils'
+import { wrapTimerFactory } from 'cozy-clisk/dist/libs/wrapTimer'
 
 const log = Minilog('ContentScript')
 Minilog.enable()
@@ -13,6 +14,21 @@ const DEFAULT_PAGE_URL =
   BASE_URL + '/fr/accueil/espace-client/tableau-de-bord.html'
 
 class EdfContentScript extends ContentScript {
+  constructor() {
+    super()
+    const logInfo = message => this.log('info', message)
+    const wrapTimerInfo = wrapTimerFactory({ logFn: logInfo })
+
+    this.fetchContact = wrapTimerInfo(this, 'fetchContact')
+    this.fetchContracts = wrapTimerInfo(this, 'fetchContracts')
+    this.fetchBillsForAllContracts = wrapTimerInfo(
+      this,
+      'fetchBillsForAllContracts'
+    )
+    this.fetchEcheancierBills = wrapTimerInfo(this, 'fetchEcheancierBills')
+    this.fetchHousing = wrapTimerInfo(this, 'fetchHousing')
+  }
+
   // ///////
   // PILOT//
   // ///////

--- a/src/index.js
+++ b/src/index.js
@@ -409,6 +409,7 @@ class EdfContentScript extends ContentScript {
       for (let acc of accList) {
         const contract = acc.accDTO
         const subPath = contracts.folders[contract.numAcc]
+        const cozyBills = []
         for (let bill of acc.listOfbills) {
           const cozyBill = {
             vendor: 'EDF',
@@ -452,14 +453,15 @@ class EdfContentScript extends ContentScript {
               carbonCopy: true
             }
           }
-          await this.saveBills([cozyBill], {
-            context,
-            subPath,
-            fileIdAttributes: ['vendorRef'],
-            contentType: 'application/pdf',
-            qualificationLabel: 'energy_invoice'
-          })
+          cozyBills.push(cozyBill)
         }
+        await this.saveBills(cozyBills, {
+          context,
+          subPath,
+          fileIdAttributes: ['vendorRef'],
+          contentType: 'application/pdf',
+          qualificationLabel: 'energy_invoice'
+        })
       }
     }
   }
@@ -697,18 +699,6 @@ class EdfContentScript extends ContentScript {
       interval: 1000,
       timeout: 30 * 1000
     })
-    return true
-  }
-
-  findAndSendCredentials() {
-    const emailField = document.querySelector('#emailHid')
-    const passwordField = document.querySelector('#password2-password-field')
-    if (emailField && passwordField) {
-      this.sendToPilot({
-        email: emailField.value,
-        password: passwordField.value
-      })
-    }
     return true
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -124,7 +124,7 @@ export function formatHousing(contracts, echeancierResult, housingArray) {
       ),
       gas: convertConsumption(
         oneHousing.rawConsumptions?.gas?.yearlyGasEnergies,
-        oneHousing.rawConsumptions?.gas.monthlyGasEnergies
+        oneHousing.rawConsumptions?.gas?.monthlyGasEnergies
       )
     }
     const contractId = checkPdlNumber(contracts, oneHousing.pdlNumber)


### PR DESCRIPTION
Maintenant ce connecteur peut n'exécuter que certains parties de son scraping en fonction des données de contexte.

- Si la dernière exécution du connecteur est en erreur, on récupère tout
- Si la dernière exécution du connecteur date d'il y a plus de 30 jours, on récupère tout
- Si l'identity date d'il y a plus de 30 jours, on on la rerécupère.nt identity is more than 30 days fetch housing data

Ces critères sont un peu arbitraires pour le moment et pourrons sûrement être améliorés dans le futur

J'ai tenté de me baser sur la date des fichiers des factures récupérées mais les dates de mises à jour sont trop aléatoires pour mon compte en tous cas. De plus, une partie des données nécessaires à l'identity est scrapée au moment de la récupération des factures donc pas moyen de dissocier les 2


Since this vendor_link is not used flagship app anymore to load the
pilot on anymore- feat: Now use default edf particulier page in vendor_link
- fix: Protection on non populated gas data
- fix: Properly detect existing account
- fix: Now query edf json api from worker
- refactor: Subscribe to login form worker event from pilot
- feat: Upgrade cozy-clisk
- feat: Mesure time taken by main konnector methods
- feat: Only one saveBills for more perf
- feat: Fetch housing data only when needed
Since this vendor_link is not used flagship app anymore to load the
pilot on anymore