### PR TITLE
fix: Change name back to EDF

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -1,6 +1,6 @@
 {
   "version": "2.11.0",
-  "name": "Edf",
+  "name": "EDF",
   "type": "konnector",
   "language": "node",
   "clientSide": true,


### PR DESCRIPTION
This was the name used by the nodejs konnector and this is the name used
to create the folder where the konnector destination folder will be
created.

Or else this can generate conflicts.

We will find a better way to avoid these conflicts in a second step.
