### PR TITLE
fix: Add retry in goToLoginForm

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,6 @@ class EdfContentScript extends ContentScript {
 
   async tryAutoLogin(credentials) {
     this.log('info', '🤖 autologin start')
-    await this.goto(DEFAULT_PAGE_URL)
     await Promise.all([
       this.autoLogin(credentials),
       this.waitForAuthenticatedWithRetry()

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,11 @@ class EdfContentScript extends ContentScript {
   }
 
   async logout() {
-    window.deconnexion()
+    if (window.deconnexion) {
+      window.deconnexion()
+    } else {
+      throw new Error('Could not logout from the current page. No window.deconnexion function found')
+    }
   }
 
   async ensureAuthenticated({ account }) {


### PR DESCRIPTION
When we got an error page after goToLoginForm, we could not logout from
the current account in ensureNotAuthenticated

Now, we make sure we do not have an error page in the end of
goToLoginForm and if there is an error page, we retry once

- fix: Explicit error when logout is impossible
- fix: No not to reload page before autologin
