### PR TITLE
fix: Change of logout method 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,26 +167,13 @@ class EdfContentScript extends ContentScript {
   }
   async ensureNotAuthenticated() {
     this.log('info', '🤖 starting ensureNotAuthenticated')
-    await this.goToLoginForm()
-    const authenticated = await this.runInWorker('checkAuthenticated')
-    if (authenticated === false) {
-      this.log('info', 'Already not authenticated')
-      return true
-    }
-    this.log('info', 'authenticated, triggering the deconnection')
-    await this.runInWorker('logout')
-    await this.waitForElementInWorker(`[data-label='Je me reconnecte']`)
+    await this.goto(
+      'https://particulier.edf.fr/fr/accueil/espace-client/moduleopenidc.html?logout='
+    )
+    await this.waitForElementInWorker(
+      `[data-label='Je me reconnecte'], .auth #email`
+    )
     return true
-  }
-
-  async logout() {
-    if (window.deconnexion) {
-      window.deconnexion()
-    } else {
-      throw new Error(
-        'Could not logout from the current page. No window.deconnexion function found'
-      )
-    }
   }
 
   async ensureAuthenticated({ account }) {
@@ -1252,7 +1239,6 @@ connector
       'getContractElec',
       'getConsumptions',
       'waitForSessionStorage',
-      'logout',
       'selectContract',
       'resetCurrentContract',
       'getContractPdlNumber',

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,7 @@ class EdfContentScript extends ContentScript {
     const logInfo = message => this.log('info', message)
     const wrapTimerInfo = wrapTimerFactory({ logFn: logInfo })
 
+    this.goToLoginForm = wrapTimerInfo(this, 'goToLoginForm')
     this.fetchContact = wrapTimerInfo(this, 'fetchContact')
     this.fetchContracts = wrapTimerInfo(this, 'fetchContracts')
     this.fetchBillsForAllContracts = wrapTimerInfo(
@@ -194,7 +195,9 @@ class EdfContentScript extends ContentScript {
     if (!account) {
       await this.ensureNotAuthenticated()
     }
-    await this.goToLoginForm()
+    if (!(await this.isElementInWorker('.auth #email'))) {
+      await this.goToLoginForm()
+    }
     if (await this.runInWorker('checkAuthenticated')) {
       this.log('info', 'Authenticated')
       return true


### PR DESCRIPTION
We see in connector logs that the logout could block the execution for
some users.
I found another method to do this logout which is faster and looks more
reliable. We just visit a dedicated url

- feat: goToLoginForm only when needed
