### PR TITLE
[SCR-196] feat: Set error result to UNKNOWN_ERROR.PARTIAL_SYNC when needed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -367,17 +367,22 @@ class EdfContentScript extends ContentScript {
         `Existing identity updated since more than 30 days or no identity. Updating it`
       )
       const identity = { contact }
-      const housingRawData = await this.fetchHousing()
-      if (housingRawData !== null) {
-        const housing = formatHousing(
-          contracts,
-          echeancierResult,
-          housingRawData,
-          this.log.bind(this)
-        )
-        identity.housing = housing
+      try {
+        const housingRawData = await this.fetchHousing()
+        if (housingRawData !== null) {
+          const housing = formatHousing(
+            contracts,
+            echeancierResult,
+            housingRawData,
+            this.log.bind(this)
+          )
+          identity.housing = housing
+        }
+        await this.saveIdentity(identity)
+      } catch (err) {
+        this.log('error', `Got an error while fetching housing data`)
+        throw new Error('UNKNOWN_ERROR.PARTIAL_SYNC')
       }
-      await this.saveIdentity(identity)
     } else {
       this.log(
         'info',


### PR DESCRIPTION
If we had an error only in the fetch consumption phase
